### PR TITLE
Fix: Use https instead of http for download URLs.

### DIFF
--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -25,10 +25,10 @@ when 'debian'
   include_recipe 'apt'
 
   apt_repository 'erlang_solutions_repo' do
-    uri 'http://packages.erlang-solutions.com/debian/'
+    uri 'https://packages.erlang-solutions.com/debian/'
     distribution node['erlang']['esl']['lsb_codename']
     components ['contrib']
-    key 'http://packages.erlang-solutions.com/debian/erlang_solutions.asc'
+    key 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc'
     action :add
   end
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -36,7 +36,7 @@ when 'rhel'
 
     yum_repository 'EPELErlangrepo' do
       description "Updated erlang yum repository for RedHat / Centos 5.x - #{node['kernel']['machine']}"
-      baseurl 'http://repos.fedorapeople.org/repos/peter/erlang/epel-5Server/$basearch'
+      baseurl 'https://repos.fedorapeople.org/repos/peter/erlang/epel-5Server/$basearch'
       gpgcheck false
       sslverify false
       action :create

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -38,7 +38,7 @@ erlang_deps.each do |pkg|
 end
 
 erlang_version     = node['erlang']['source']['version']
-erlang_url         = node['erlang']['source']['url'] || "http://erlang.org/download/otp_src_#{erlang_version}.tar.gz"
+erlang_url         = node['erlang']['source']['url'] || "https://erlang.org/download/otp_src_#{erlang_version}.tar.gz"
 erlang_checksum    = node['erlang']['source']['checksum']
 erlang_build_flags = node['erlang']['source']['build_flags']
 erlang_cflags      = node['erlang']['source']['cflags']


### PR DESCRIPTION
This PR updates download URLs to use `https` instead of `http`, for safety.