### PR TITLE
Added logic that enables installing erlang from erlang solutions repo…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,9 @@
 default['erlang']['gui_tools'] = false
 default['erlang']['install_method'] = 'package'
 
+default['erlang']['package']['use_erlang_solutions_repo'] = false
+default['erlang']['package']['version'] = nil
+
 default['erlang']['source']['version'] = '18.3'
 default['erlang']['source']['checksum'] = 'fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3'
 default['erlang']['source']['build_flags'] = ''

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -43,6 +43,9 @@ when 'rhel'
     end
   end
 
+  include_recipe 'yum-erlang_solutions' if node['erlang']['package']['use_erlang_solutions_repo']
   include_recipe 'yum-epel'
-  package 'erlang'
+  package 'erlang' do
+    version node['erlang']['package']['version'] if node['erlang']['package']['version']
+  end
 end


### PR DESCRIPTION
This change adds the ability to install erlang from the erlang solutions repository. For Centos 6 and 7 the erlang version from Epel is too old for software that uses erlang like rabbitmq.
