### PR TITLE
Bats->InSpec, fixes, and updates

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -89,9 +89,9 @@ platforms:
     intermediate_instructions:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
 
-- name: opensuse-42.2
+- name: opensuse-leap
   driver:
-    image: opensuse:42.2
+    image: opensuse:leap
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which hostname

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -11,8 +11,7 @@ provisioner:
   name: dokken
 
 verifier:
-  root_path: '/opt/verifier'
-  sudo: false
+  name: inspec
 
 platforms:
 - name: debian-7
@@ -90,9 +89,9 @@ platforms:
     intermediate_instructions:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
 
-- name: opensuse-42.1
+- name: opensuse-42.2
   driver:
-    image: opensuse:42.1
+    image: opensuse:42.2
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which hostname
@@ -114,6 +113,11 @@ suites:
 - name: esl
   run_list:
     - recipe[erlang::esl]
+  excludes:
+    - centos-5
+    - fedora-latest
+    - opensuse-13.2
+    - opensuse-42.2    
 
 - name: source
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -45,6 +45,9 @@ suites:
     - recipe[erlang::esl]
   excludes:
     - centos-5.11
+    - fedora-25
+    - opensuse-13.2
+    - opensuse-42.2  
 
 - name: source
   run_list:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Manages installation of Erlang via packages or source.
 
 - Debian/Ubuntu
 - RHEL/CentOS/Scientific/Amazon/Oracle
+- Fedora
+- openSUSE
 
 ### Chef
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,8 @@
 default['erlang']['gui_tools'] = false
 default['erlang']['install_method'] = 'package'
 
-default['erlang']['source']['version'] = '18.3'
-default['erlang']['source']['checksum'] = 'fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3'
+default['erlang']['source']['version'] = '19.2'
+default['erlang']['source']['checksum'] = 'a016b3ef5dac1e532972617b2715ef187ecb616f7cd7ddcfe0f1d502f5d24870'
 default['erlang']['source']['build_flags'] = ''
 default['erlang']['source']['cflags'] = ''
 

--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -21,6 +21,8 @@
 
 case node['platform_family']
 when 'debian'
+  package 'apt-transport-https'
+
   apt_repository 'erlang_solutions_repo' do
     uri 'https://packages.erlang-solutions.com/debian/'
     distribution node['erlang']['esl']['lsb_codename']

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -27,7 +27,7 @@ when 'debian'
   package erlpkg
   package 'erlang-dev'
 
-when 'rhel'
+when 'rhel', 'suse', 'fedora'
   if node['platform_version'].to_i == 5
     Chef::Log.warn('Adding EPEL Erlang Repo. This will have SSL verification disabled, as')
     Chef::Log.warn('RHEL/CentOS 5.x will not be able to verify the SSL certificate of this')
@@ -43,6 +43,6 @@ when 'rhel'
     end
   end
 
-  include_recipe 'yum-epel'
+  include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
   package 'erlang'
 end

--- a/test/integration/default/bats/run_an_erlang_command.sh
+++ b/test/integration/default/bats/run_an_erlang_command.sh
@@ -1,5 +1,0 @@
-@test "run an erl command" {
-  sudo bash -c 'erl -myflag 1 <<-EOH
-init:get_argument(myflag).
-EOH'
-}

--- a/test/integration/default/inspec/default_test.rb
+++ b/test/integration/default/inspec/default_test.rb
@@ -1,0 +1,16 @@
+# # encoding: utf-8
+
+# this check works on all versions
+check = "erl -eval \'erlang:display(erlang:system_info(otp_release)), halt().\'  -noshell"
+ver = command(check).stdout
+
+if ver =~ /R\d*B\d*/
+  describe command(check) do
+    its('stdout') { should match /R\d*B\d*/ }
+  end
+else
+  cmd = 'erl -eval \'{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().\''
+  describe command(cmd) do
+    its('stdout') { should match /\d?\.\d/ }
+  end
+end

--- a/test/integration/esl/bats/run_an_erlang_command.sh
+++ b/test/integration/esl/bats/run_an_erlang_command.sh
@@ -1,5 +1,0 @@
-@test "run an erl command" {
-  sudo bash -c 'erl -myflag 1 <<-EOH
-init:get_argument(myflag).
-EOH'
-}

--- a/test/integration/esl/inspec/esl_test.rb
+++ b/test/integration/esl/inspec/esl_test.rb
@@ -1,0 +1,16 @@
+# # encoding: utf-8
+
+# this check works on all versions
+check = "erl -eval \'erlang:display(erlang:system_info(otp_release)), halt().\'  -noshell"
+ver = command(check).stdout
+
+if ver =~ /R\d*B\d*/
+  describe command(check) do
+    its('stdout') { should match /R\d*B\d*/ }
+  end
+else
+  cmd = 'erl -eval \'{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().\''
+  describe command(cmd) do
+    its('stdout') { should match /\d?\.\d/ }
+  end
+end

--- a/test/integration/source/bats/run_an_erlang_command.sh
+++ b/test/integration/source/bats/run_an_erlang_command.sh
@@ -1,5 +1,0 @@
-@test "run an erl command" {
-  sudo bash -c 'erl -myflag 1 <<-EOH
-init:get_argument(myflag).
-EOH'
-}

--- a/test/integration/source/inspec/source_test.rb
+++ b/test/integration/source/inspec/source_test.rb
@@ -1,0 +1,16 @@
+# # encoding: utf-8
+
+# this check works on all versions
+check = "erl -eval \'erlang:display(erlang:system_info(otp_release)), halt().\'  -noshell"
+ver = command(check).stdout
+
+if ver =~ /R\d*B\d*/
+  describe command(check) do
+    its('stdout') { should match /R\d*B\d*/ }
+  end
+else
+  cmd = 'erl -eval \'{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().\''
+  describe command(cmd) do
+    its('stdout') { should match /\d?\.\d/ }
+  end
+end


### PR DESCRIPTION
- Replace Bats tests with InSpec
- Fix builds for Fedora and openSUSE
- Exclude Fedora and openSUSE from ESL as there aren't repos for these
- Update source version to latest `19.2`


Signed-off-by: Seth Thomas <sthomas@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
