### PR TITLE
Loosen up depends on yum cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '4.1.0'
 
 depends           'apt', '>= 1.7.0'
-depends           'yum', '~> 3.0'
+depends           'yum', '>= 3.0'
 depends           'yum-epel'
 depends           'yum-erlang_solutions'
 depends           'build-essential'


### PR DESCRIPTION
### Description

Loosen up depends on yum cookbook

### Issues Resolved

Allows yum 4.x to be used as well

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
