### PR TITLE
Ubuntu 16.04 nox package

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -23,8 +23,10 @@
 
 case node['platform_family']
 when 'debian'
-  erlpkg = node['erlang']['gui_tools'] ? 'erlang-x11' : 'erlang-nox'
-  package erlpkg
+  if node['platform_version'].to_i < 16.04
+    erlpkg = node['erlang']['gui_tools'] ? 'erlang-x11' : 'erlang-nox'
+    package erlpkg
+  end
   package 'erlang-dev'
 
 when 'rhel', 'suse', 'fedora'


### PR DESCRIPTION
- It seems that erlang-nox was removed in 16.04, this puts some logic
  around it to make sure it works

Signed-off-by: JJ Asghar <jj@chef.io>
