### PR TITLE
Added support for Amazon platform family

### DIFF
--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -34,7 +34,7 @@ when 'debian'
   package 'esl-erlang' do
     version node['erlang']['esl']['version'] if node['erlang']['esl']['version']
   end
-when 'rhel'
+when 'rhel', 'amazon'
   if node['platform_version'].to_i <= 5
     Chef::Log.fatal('Erlang Solutions package repositories are not available for EL5')
     raise

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -29,7 +29,7 @@ when 'debian'
   end
   package 'erlang-dev'
 
-when 'rhel', 'suse', 'fedora'
+when 'rhel', 'suse', 'fedora', 'amazon'
   if node['platform_version'].to_i == 5 && node['erlang']['package']['install_epel_repository']
     Chef::Log.warn('Adding EPEL Erlang Repo. This will have SSL verification disabled, as')
     Chef::Log.warn('RHEL/CentOS 5.x will not be able to verify the SSL certificate of this')

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -25,7 +25,7 @@ include_recipe 'build-essential'
 case node['platform_family']
 when 'debian'
   package %w(tar libncurses5-dev openssl libssl-dev)
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   package %w(tar ncurses-devel openssl-devel)
 when 'suse'
   package %w(tar ncurses-devel libopenssl-devel)


### PR DESCRIPTION
### Description
Amazon Linux now has it's own platform family defined by ohai. Since it is no longer categorized under rhel, resources based on case node[platform_family] will be skipped.
[Describe what this change achieves]

### Issues Resolved
Resources based on case node[platform_family] will now run on Amazon Linux as well.
[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
