### PR TITLE
Allow specifying a mirror of the ESL repository.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,5 +29,13 @@ default['erlang']['source']['cflags'] = ''
 default['erlang']['esl']['version'] = nil
 default['erlang']['esl']['lsb_codename'] = node['lsb'] ? node['lsb']['codename'] : 'no_lsb'
 
+# NOTE: these parameters are only used by Debian and derivatives. On Red
+# Hat-based systems, use the equivalent parameters in the
+# `yum-erlang_solutions` cookbook:
+# default['yum']['erlang_solutions']['baseurl']
+# default['yum']['erlang_solutions']['gpgkey']
+default['erlang']['esl']['repo']['uri'] = 'https://packages.erlang-solutions.com/debian/'
+default['erlang']['esl']['repo']['key'] = 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc'
+
 default['erlang']['package']['version'] = nil
 default['erlang']['package']['install_epel_repository'] = true

--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -24,10 +24,10 @@ when 'debian'
   package 'apt-transport-https'
 
   apt_repository 'erlang_solutions_repo' do
-    uri 'https://packages.erlang-solutions.com/debian/'
+    uri node['erlang']['esl']['repo']['uri']
     distribution node['erlang']['esl']['lsb_codename']
     components ['contrib']
-    key 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc'
+    key node['erlang']['esl']['repo']['key']
     action :add
   end
 


### PR DESCRIPTION
### Description

This change allows specifying an internal mirror to install Erlang from Erlang Solutions, and defaults to values which were previously hard-coded.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
