### PR TITLE
Update esl.rb

### DIFF
--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -34,7 +34,7 @@ when 'debian'
   apt_preference 'erlang_solutions_repo' do
     package_name 'esl-erlang'
     pin "version #{node['erlang']['esl']['version']}"
-    pin_priority 700
+    pin_priority '700'
     action :add
     not_if { node['erlang']['esl']['version'].nil? }
   end


### PR DESCRIPTION
When cloning this project, I am getting the following error from my Chef client "Chef::Exceptions::ValidationFailed: Property pin_priority must be one of: String!  You passed 700.", it requires the 700 to be a String.

### Description

Changes the 700 pin_priority value to a string, so that it is usable by the Chef client.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
